### PR TITLE
Update readme for Composer 2.0 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation:
 
 ```bash
-composer require Stowers-LIMS/zpl
+composer require stowers-lims/zpl
 ```
 
 ## How to use:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## This library is a php wrapper for the ZPL Programming Language.
+
 ---
+
 ## Installation:
 
 ```bash


### PR DESCRIPTION
In April, the library was renamed to be cool for upcoming Composer 2.0 compatibility. This change makes the README example use the new name (all-lower-case).

As a bonus, the title no longer starts with two hash signs.